### PR TITLE
:bug: Fix invalid argument for foreach, standardize indent

### DIFF
--- a/woocommerce-shipcloud.php
+++ b/woocommerce-shipcloud.php
@@ -521,17 +521,17 @@ class WooCommerce_Shipcloud {
 	 *
 	 * @since 1.0.0
 	 * @since 1.2.0 Uses session as collection of notices.
-   * @since 1.14.0 remove sessions and handle as transient
+	 * @since 1.14.0 remove sessions and handle as transient
 	 */
 	public static function show_admin_notices() {
-    $shipcloud_notices = get_transient( 'shipcloud_notices' );
-    if ( !isset($shipcloud_notices) ) {
-      $shipcloud_notices = array();
-    }
+		$shipcloud_notices = get_transient( 'shipcloud_notices' );
+		if ( !isset($shipcloud_notices) || !is_array($shipcloud_notices) ) {
+			$shipcloud_notices = array();
+		}
 
-    foreach ( $shipcloud_notices as $notice ) {
-      echo '<div class="' . esc_attr( $notice['type'] ) . '"><p>' . $notice['message'] . '</p></div>';
-    }
+		foreach ( $shipcloud_notices as $notice ) {
+			echo '<div class="' . esc_attr( $notice['type'] ) . '"><p>' . $notice['message'] . '</p></div>';
+		}
 	}
 
 	/**


### PR DESCRIPTION
When changing themes, the plugin currently produces the following notice:

```
Warning:  Invalid argument supplied for foreach() in /var/www/html/wp-content/plugins/shipcloud-for-woocommerce/woocommerce-shipcloud.php on line 534
Stack trace:
  1. {main}() /var/www/html/wp-admin/themes.php:0
  2. require_once() /var/www/html/wp-admin/themes.php:1158
  3. do_action($hook_name = 'admin_footer', ...$arg = variadic('')) /var/www/html/wp-admin/admin-footer.php:78
  4. WP_Hook->do_action($args = [0 => '']) /var/www/html/wp-includes/plugin.php:470
  5. WP_Hook->apply_filters($value = '', $args = [0 => '']) /var/www/html/wp-includes/class-wp-hook.php:327
  6. WooCommerce_Shipcloud::show_admin_notices('') /var/www/html/wp-includes/class-wp-hook.php:303
```

# What has changed?

- Instead of assuming `get_transient( 'shipcloud_notices' )` is an array, check for it.
- Fixed indentation of this method and DocBlock.

Common things:

- [ ] Works fine.
- [ ] Changelog written or not needed.
- [ ] In case of bugfix also merged in other minor versions.
- [ ] No conflict with current branch.


